### PR TITLE
Provision API should not create a new account if called again with same quicknode-id + Small README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The application has 4 provisioning routes protected by HTTP Basic Auth:
 
 - `POST /provision`
 - `PUT /update`
-- `DELETE /deactivate`
+- `DELETE /deactivate_endpoint`
 - `DELETE /deprovision`
 
 It has a public healthcheck route that returns 200 if the service and the database is up and running:


### PR DESCRIPTION
This PR does two things:

1. It fixes the README which had the wrong URL listed for `/deactivate_endpoint`
2. It fixes a bug that caused a new account to be inserted in the DB if user calls provision multiple times with the same quicknode-id.